### PR TITLE
Feat 1

### DIFF
--- a/src/main/java/doodoom/project/peermarket/configuration/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/doodoom/project/peermarket/configuration/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,29 @@
+package doodoom.project.peermarket.configuration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        String msg = "로그인에 실패하였습니다.";
+
+        if (exception instanceof InternalAuthenticationServiceException) {
+            msg = exception.getMessage();
+        }
+        setDefaultFailureUrl("/member/login?error=true");
+        request.setAttribute("errorMessage", msg);
+
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/configuration/JpaAuditingConfig.java
+++ b/src/main/java/doodoom/project/peermarket/configuration/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package doodoom.project.peermarket.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/doodoom/project/peermarket/configuration/SecurityConfig.java
+++ b/src/main/java/doodoom/project/peermarket/configuration/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
 @Configuration
 public class SecurityConfig {
@@ -15,14 +16,34 @@ public class SecurityConfig {
     }
 
     @Bean
+    AuthenticationFailureHandler getFailureHandler() {
+        return new CustomAuthenticationFailureHandler();
+    }
+
+    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable();
 
         http.authorizeRequests()
                 .antMatchers(
                         "/",
-                        "member/register"
+                        "/member/register"
                 )
+                .permitAll();
+
+        http.authorizeRequests()
+                .antMatchers("/admin/**")
+                .hasAuthority("ROLE_ADMIN");
+
+        http.formLogin()
+                .loginPage("/member/login")
+                .failureHandler(getFailureHandler())
+                .permitAll();
+
+        http.logout()
+                .logoutSuccessUrl("/")
+                .deleteCookies("JSESSIONID")
+                .invalidateHttpSession(true)
                 .permitAll();
 
         return http.build();

--- a/src/main/java/doodoom/project/peermarket/configuration/SecurityConfig.java
+++ b/src/main/java/doodoom/project/peermarket/configuration/SecurityConfig.java
@@ -1,0 +1,30 @@
+package doodoom.project.peermarket.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+
+        http.authorizeRequests()
+                .antMatchers(
+                        "/",
+                        "member/register"
+                )
+                .permitAll();
+
+        return http.build();
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/controller/MemberController.java
+++ b/src/main/java/doodoom/project/peermarket/controller/MemberController.java
@@ -1,0 +1,29 @@
+package doodoom.project.peermarket.controller;
+
+import doodoom.project.peermarket.dto.MemberRegisterInput;
+import doodoom.project.peermarket.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Controller
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/member/register")
+    public String getRegister(Model model) {
+        model.addAttribute("input", new MemberRegisterInput());
+        return "member/register";
+    }
+
+    @PostMapping("/member/register")
+    public String register(@Valid MemberRegisterInput input) {
+        memberService.register(input);
+        return "redirect:/";
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/controller/MemberController.java
+++ b/src/main/java/doodoom/project/peermarket/controller/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.validation.Valid;
 
@@ -25,5 +26,10 @@ public class MemberController {
     public String register(@Valid MemberRegisterInput input) {
         memberService.register(input);
         return "redirect:/";
+    }
+
+    @RequestMapping("/member/login")
+    public String getLogin() {
+        return "member/login";
     }
 }

--- a/src/main/java/doodoom/project/peermarket/domain/Member.java
+++ b/src/main/java/doodoom/project/peermarket/domain/Member.java
@@ -25,4 +25,5 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
+    private Boolean isAdmin;
 }

--- a/src/main/java/doodoom/project/peermarket/domain/Member.java
+++ b/src/main/java/doodoom/project/peermarket/domain/Member.java
@@ -1,0 +1,28 @@
+package doodoom.project.peermarket.domain;
+
+import doodoom.project.peermarket.domain.base.BaseTimeEntity;
+import doodoom.project.peermarket.type.MemberStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    private Long id;
+    private String email;
+    private String password;
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+}

--- a/src/main/java/doodoom/project/peermarket/domain/base/BaseTimeEntity.java
+++ b/src/main/java/doodoom/project/peermarket/domain/base/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package doodoom.project.peermarket.domain.base;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/java/doodoom/project/peermarket/dto/ErrorResponse.java
+++ b/src/main/java/doodoom/project/peermarket/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package doodoom.project.peermarket.dto;
+
+import doodoom.project.peermarket.type.ErrorCode;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String errorMessage;
+}

--- a/src/main/java/doodoom/project/peermarket/dto/MemberRegisterInput.java
+++ b/src/main/java/doodoom/project/peermarket/dto/MemberRegisterInput.java
@@ -1,0 +1,32 @@
+package doodoom.project.peermarket.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberRegisterInput {
+
+    @Email(message = "올바른 형식의 이메일 주소여야 합니다.")
+    private String email;
+    @NotEmpty(message = "비밀번호는 필수 입력 사항입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d~!@#$%^&*()+|=]{8," +
+            "20}$", message = "비밀번호는 영어, 숫자를 포함해 8~20 글자이어야 합니다.")
+    private String password;
+    @NotEmpty(message = "비밀번호 확인은 필수 입력 사항입니다.")
+    private String passwordCheck;
+    @NotEmpty(message = "닉네임은 필수 입력 사항입니다.")
+    private String nickname;
+
+    @AssertTrue(message = "비밀번호가 일치하지 않습니다.")
+    boolean isEqualPassword() {
+        return this.password.equals(this.passwordCheck);
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doodoom/project/peermarket/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package doodoom.project.peermarket.exception;
+
+import doodoom.project.peermarket.dto.ErrorResponse;
+import doodoom.project.peermarket.type.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static doodoom.project.peermarket.type.ErrorCode.INPUT_FIELD_ERROR;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<?> handleMemberException(MemberException e) {
+        log.warn("{} is occurred", e.getErrorCode());
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(e.getErrorCode())
+                .errorMessage(e.getErrorMessage())
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<?> handleBindException(BindException e) {
+        log.warn("{} is occurred", INPUT_FIELD_ERROR);
+        List<ErrorResponse> responses = new ArrayList<>();
+        for (FieldError error : e.getFieldErrors()) {
+            responses.add(ErrorResponse.builder()
+                    .errorCode(INPUT_FIELD_ERROR)
+                    .errorMessage(error.getDefaultMessage())
+                    .build());
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responses);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleException(Exception e) {
+        log.error("{} is occurred", ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e);
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/exception/GlobalExceptionHandler.java
+++ b/src/main/java/doodoom/project/peermarket/exception/GlobalExceptionHandler.java
@@ -1,10 +1,8 @@
 package doodoom.project.peermarket.exception;
 
 import doodoom.project.peermarket.dto.ErrorResponse;
-import doodoom.project.peermarket.type.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -20,31 +18,33 @@ import static doodoom.project.peermarket.type.ErrorCode.INPUT_FIELD_ERROR;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MemberException.class)
-    public ResponseEntity<?> handleMemberException(MemberException e) {
+    public String handleMemberException(MemberException e, Model model) {
         log.warn("{} is occurred", e.getErrorCode());
-        ErrorResponse response = ErrorResponse.builder()
+        ErrorResponse errorResponse = ErrorResponse.builder()
                 .errorCode(e.getErrorCode())
                 .errorMessage(e.getErrorMessage())
                 .build();
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        model.addAttribute("errorResponse", errorResponse);
+        return "error/400";
     }
 
     @ExceptionHandler(BindException.class)
-    public ResponseEntity<?> handleBindException(BindException e) {
+    public String handleBindException(BindException e, Model model) {
         log.warn("{} is occurred", INPUT_FIELD_ERROR);
-        List<ErrorResponse> responses = new ArrayList<>();
+        List<ErrorResponse> errorResponses = new ArrayList<>();
         for (FieldError error : e.getFieldErrors()) {
-            responses.add(ErrorResponse.builder()
+            errorResponses.add(ErrorResponse.builder()
                     .errorCode(INPUT_FIELD_ERROR)
                     .errorMessage(error.getDefaultMessage())
                     .build());
         }
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responses);
+        model.addAttribute("errorResponses", errorResponses);
+        return "error/validation";
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> handleException(Exception e) {
-        log.error("{} is occurred", ErrorCode.INTERNAL_SERVER_ERROR);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e);
+    public String handleException(Exception e) {
+        log.error("{} is occurred", e.getMessage());
+        return "error/500";
     }
 }

--- a/src/main/java/doodoom/project/peermarket/exception/MemberException.java
+++ b/src/main/java/doodoom/project/peermarket/exception/MemberException.java
@@ -1,0 +1,15 @@
+package doodoom.project.peermarket.exception;
+
+import doodoom.project.peermarket.type.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String errorMessage;
+
+    public MemberException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/repository/MemberRepository.java
+++ b/src/main/java/doodoom/project/peermarket/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package doodoom.project.peermarket.repository;
+
+import doodoom.project.peermarket.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/doodoom/project/peermarket/service/member/MemberService.java
+++ b/src/main/java/doodoom/project/peermarket/service/member/MemberService.java
@@ -1,0 +1,7 @@
+package doodoom.project.peermarket.service.member;
+
+import doodoom.project.peermarket.dto.MemberRegisterInput;
+
+public interface MemberService {
+    boolean register(MemberRegisterInput input);
+}

--- a/src/main/java/doodoom/project/peermarket/service/member/MemberService.java
+++ b/src/main/java/doodoom/project/peermarket/service/member/MemberService.java
@@ -1,7 +1,8 @@
 package doodoom.project.peermarket.service.member;
 
 import doodoom.project.peermarket.dto.MemberRegisterInput;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
-public interface MemberService {
+public interface MemberService extends UserDetailsService {
     boolean register(MemberRegisterInput input);
 }

--- a/src/main/java/doodoom/project/peermarket/service/member/MemberServiceImpl.java
+++ b/src/main/java/doodoom/project/peermarket/service/member/MemberServiceImpl.java
@@ -1,0 +1,38 @@
+package doodoom.project.peermarket.service.member;
+
+import doodoom.project.peermarket.domain.Member;
+import doodoom.project.peermarket.dto.MemberRegisterInput;
+import doodoom.project.peermarket.exception.MemberException;
+import doodoom.project.peermarket.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static doodoom.project.peermarket.type.ErrorCode.EMAIL_ALREADY_EXIST;
+import static doodoom.project.peermarket.type.MemberStatus.ACTIVE;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public boolean register(MemberRegisterInput input) {
+        if (memberRepository.findByEmail(input.getEmail()).isPresent()) {
+            throw new MemberException(EMAIL_ALREADY_EXIST);
+        }
+        Member member = Member.builder()
+                .email(input.getEmail())
+                .password(passwordEncoder.encode(input.getPassword()))
+                .nickname(input.getNickname())
+                .status(ACTIVE)
+                .build();
+        memberRepository.save(member);
+        return true;
+    }
+}

--- a/src/main/java/doodoom/project/peermarket/type/ErrorCode.java
+++ b/src/main/java/doodoom/project/peermarket/type/ErrorCode.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     EMAIL_ALREADY_EXIST("이메일이 중복 되었습니다."),
+    MEMBER_NOT_FOUND("존재하지 않는 이메일입니다."),
+    MEMBER_ALREADY_STOP("계정이 정지 되었습니다."),
     INTERNAL_SERVER_ERROR("서버 에러가 발생했습니다."),
     INPUT_FIELD_ERROR("입력 값이 올바르지 않습니다.");
     private final String description;

--- a/src/main/java/doodoom/project/peermarket/type/ErrorCode.java
+++ b/src/main/java/doodoom/project/peermarket/type/ErrorCode.java
@@ -1,0 +1,13 @@
+package doodoom.project.peermarket.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    EMAIL_ALREADY_EXIST("이메일이 중복 되었습니다."),
+    INTERNAL_SERVER_ERROR("서버 에러가 발생했습니다."),
+    INPUT_FIELD_ERROR("입력 값이 올바르지 않습니다.");
+    private final String description;
+}

--- a/src/main/java/doodoom/project/peermarket/type/MemberStatus.java
+++ b/src/main/java/doodoom/project/peermarket/type/MemberStatus.java
@@ -1,0 +1,5 @@
+package doodoom.project.peermarket.type;
+
+public enum MemberStatus {
+    ACTIVE, STOP
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,17 @@
+spring :
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:~/p2p
+    username: sa
+    password:
 
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug

--- a/src/main/resources/templates/error/400.html
+++ b/src/main/resources/templates/error/400.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head th:replace="fragments/header :: header">
+    <title>Error page</title>
+</head>
+
+<body>
+<div class="d-flex align-items-center justify-content-center vh-100">
+    <div class="text-center">
+        <h1 class="display-1 fw-bold">400</h1>
+        <p class="fs-3" th:text="${errorResponse.errorCode}">BAD REQUEST</p>
+        <p class="lead" th:text="${errorResponse.errorMessage}"></p>
+        <a th:href="@{/member/register}" class="btn btn-primary" style="border-color: black; background-color: black">돌아가기</a>
+    </div>
+</div>
+
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head th:replace="fragments/header :: header">
+    <title>Error page</title>
+</head>
+
+<body>
+<div class="d-flex align-items-center justify-content-center vh-100">
+    <div class="text-center">
+        <h1 class="display-1 fw-bold">500</h1>
+        <p class="fs-3">INTERNAL SEVER ERROR</p>
+    </div>
+</div>
+
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/error/validation.html
+++ b/src/main/resources/templates/error/validation.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head th:replace="fragments/header :: header">
+    <title>Error page</title>
+</head>
+
+<body>
+<div class="d-flex align-items-center justify-content-center vh-100">
+    <div class="text-center">
+        <h1 class="display-1 fw-bold">400</h1>
+        <div th:each="errorResponse : ${errorResponses}">
+            <p class="fs-3" th:text="${errorResponse.errorCode}">VALIDATION ERROR</p>
+            <p class="lead" th:text="${errorResponse.errorMessage}"></p>
+        </div>
+        <a th:href="@{/member/register}" class="btn btn-primary" style="border-color: black; background-color: black">돌아가기</a>
+    </div>
+</div>
+
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<style>
+    footer>.p-3 {
+        padding: 2rem!important;
+    }
+</style>
+
+<div class="footer" th:fragment="footer">
+    <footer class="text-center text-white sticky-xl-bottom" style="background-color: #21081a; width: 100%;
+    height: 60px;
+    position: absolute;
+    bottom: 0;
+    left: 0;">
+        <!-- Grid container -->
+
+        <!-- Copyright -->
+        <div class="text-center p-3" style="background-color: rgba(0, 0, 0, 0.2);">
+            © PeerMarket V1 Copyright
+        </div>
+        <!-- Copyright -->
+    </footer>
+</div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head th:fragment="header">
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-
+  to-fit=no">
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="/css/bootstrap.min.css" integrity="sha384-
+  ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+          crossorigin="anonymous">
+    <!-- Custom styles for this template -->
+    <link href="/css/jumbotron-narrow.css" rel="stylesheet">
+    <title>Hello, world!</title>
+</head>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head th:replace="fragments/header :: header">
+    <titl>로그인</titl>
+</head>
+<style>
+    label {
+        margin: 3px;
+        text-align: center;
+    }
+
+    form {
+        width: 500px;
+        margin: auto !important;
+    }
+
+    input {
+        width: 450px;
+        text-align: center;
+    }
+</style>
+<body>
+<div class="container">
+    <form action="/member/login" method="post" class="card sign-form p-4 mt-5">
+        <h3 style="text-align: center">로그인</h3>
+        <div th:text="${errorMessage != null ? errorMessage : null}" style="text-align: center; color: red"></div>
+        <div class="form-group" style="margin:5px 0 5px 0;">
+            <input type="text" name="username" class="form-control" placeholder="이메일을 입력해주세요" required>
+        </div>
+
+        <div class="form-group" style="margin:5px 0 5px 0;">
+            <input type="password" name="password" placeholder="비밀번호를 입력해주세요" class="form-control" required>
+        </div>
+
+        <input class="btn btn-primary" type="submit" value="로그인"
+               style='background-color: #21081a; border-color: #21081a; margin:5px 0 5px 0;'/>
+    </form>
+
+</div>
+<!-- /container -->
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/member/register.html
+++ b/src/main/resources/templates/member/register.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head th:replace="fragments/header :: header"></head>
+<style>
+    label {
+        margin: 3px;
+        text-align: center;
+    }
+
+    form {
+        width: 500px;
+        margin: auto !important;
+    }
+
+    input {
+        width: 450px;
+        text-align: center;
+    }
+
+    p {
+        color: red;
+    }
+</style>
+<body>
+<div class="container">
+    <form th:action="@{/member/register}" th:object="${input}" method="post" class="card sign-form p-4 mt-5">
+        <h3 style="text-align: center">회원가입</h3>
+
+        <div class="form-group" style="margin:5px 0 5px 0;">
+            <input type="text" th:field="*{email}" class="form-control" placeholder="이메일을 입력해주세요">
+        </div>
+
+        <div class="form-group" style="margin:5px 0 5px 0;">
+            <input type="text" th:field="*{nickname}" class="form-control" placeholder="이름 입력해주세요">
+        </div>
+
+        <div class="form-group" style="margin:5px 0 5px 0;">
+            <input type="password" name="password" placeholder="비밀번호를 입력해주세요" th:field="*{password}"
+                   class="form-control">
+        </div>
+
+        <div class="form-group" style="margin:5px 0 5px 0;">
+            <input type="password" name="passwordCheck" placeholder="비밀번호를 확인해주세요" th:field="*{passwordCheck}"
+                   class="form-control">
+        </div>
+
+        <input class="btn btn-primary" type="submit" value="회원가입"
+               style='background-color: #21081a; border-color: #21081a; margin:5px 0 5px 0;'/>
+    </form>
+
+</div>
+<!-- /container -->
+<div th:replace="fragments/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/member/register.html
+++ b/src/main/resources/templates/member/register.html
@@ -1,7 +1,9 @@
 <!DOCTYPE HTML>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
-<head th:replace="fragments/header :: header"></head>
+<head th:replace="fragments/header :: header">
+    <titl>회원가입</titl>
+</head>
 <style>
     label {
         margin: 3px;
@@ -16,10 +18,6 @@
     input {
         width: 450px;
         text-align: center;
-    }
-
-    p {
-        color: red;
     }
 </style>
 <body>

--- a/src/test/java/doodoom/project/peermarket/controller/MemberControllerTest.java
+++ b/src/test/java/doodoom/project/peermarket/controller/MemberControllerTest.java
@@ -1,0 +1,62 @@
+package doodoom.project.peermarket.controller;
+
+import doodoom.project.peermarket.configuration.SecurityConfig;
+import doodoom.project.peermarket.domain.Member;
+import doodoom.project.peermarket.dto.MemberRegisterInput;
+import doodoom.project.peermarket.service.member.MemberService;
+import doodoom.project.peermarket.type.MemberStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@Import(SecurityConfig.class)
+class MemberControllerTest {
+
+    @MockBean
+    private MemberService memberService;
+    @Autowired
+    private MockMvc mockMvc;
+    private static final List<Member> members = new ArrayList<>();
+
+    @BeforeAll
+    public static void setUp() {
+        members.add(Member.builder()
+                .email("test@test.com")
+                .password("test123!")
+                .nickname("test")
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    @Test
+    public void registerTest() throws Exception {
+        //given
+        Member member = members.get(0);
+        MemberRegisterInput input =
+                new MemberRegisterInput(member.getEmail(), member.getPassword(),
+                        member.getPassword(), member.getNickname());
+        given(memberService.register(input)).willReturn(true);
+
+        //then
+        mockMvc.perform(post("/member/register")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .param("email", input.getEmail())
+                .param("password", input.getPassword())
+                .param("passwordCheck", input.getPasswordCheck())
+                .param("nickname", input.getNickname())
+        ).andExpect(status().isFound());
+    }
+}

--- a/src/test/java/doodoom/project/peermarket/controller/MemberControllerTest.java
+++ b/src/test/java/doodoom/project/peermarket/controller/MemberControllerTest.java
@@ -18,7 +18,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MemberController.class)
@@ -58,5 +60,19 @@ class MemberControllerTest {
                 .param("passwordCheck", input.getPasswordCheck())
                 .param("nickname", input.getNickname())
         ).andExpect(status().isFound());
+    }
+
+    @Test
+    public void getRegister() throws Exception {
+        mockMvc.perform(get("/member/register"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getLogin() throws Exception {
+        mockMvc.perform(get("/member/login"))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/doodoom/project/peermarket/repository/MemberRepositoryTest.java
+++ b/src/test/java/doodoom/project/peermarket/repository/MemberRepositoryTest.java
@@ -1,0 +1,84 @@
+package doodoom.project.peermarket.repository;
+
+import doodoom.project.peermarket.configuration.JpaAuditingConfig;
+import doodoom.project.peermarket.domain.Member;
+import doodoom.project.peermarket.type.MemberStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private static final List<Member> members = new ArrayList<>();
+
+    @BeforeAll
+    public static void setUp() {
+        members.add(Member.builder()
+                .email("test@test.com")
+                .password("test123!")
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    @Test
+    public void save() {
+        //given
+        Member member = members.get(0);
+        //when
+        memberRepository.save(member);
+
+        //then
+        List<Member> findAll = memberRepository.findAll();
+        assertThat(findAll.isEmpty()).isFalse();
+        assertThat(findAll.get(0).getEmail()).isEqualTo(member.getEmail());
+        assertThat(findAll.get(0).getPassword()).isEqualTo(member.getPassword());
+        assertThat(findAll.get(0).getStatus()).isEqualTo(member.getStatus());
+    }
+
+    @Test
+    public void findByEmail() {
+        //given
+        Member member = members.get(0);
+        memberRepository.save(member);
+
+        //when
+        Optional<Member> optionalMember =
+                memberRepository.findByEmail(member.getEmail());
+
+        //then
+        assertThat(optionalMember.isPresent()).isTrue();
+        assertThat(optionalMember.get().getEmail()).isEqualTo(member.getEmail());
+        assertThat(optionalMember.get().getPassword()).isEqualTo(member.getPassword());
+        assertThat(optionalMember.get().getStatus()).isEqualTo(member.getStatus());
+    }
+
+    @Test
+    @Rollback(value = false)
+    public void entityListeners() {
+        //given
+        Member member = members.get(0);
+
+        //when
+        memberRepository.save(member);
+
+        //then
+        Optional<Member> optionalMember =
+                memberRepository.findByEmail(member.getEmail());
+        assertThat(optionalMember.isPresent()).isTrue();
+        assertThat(optionalMember.get().getCreatedAt()).isNotNull();
+        assertThat(optionalMember.get().getLastModifiedAt()).isNotNull();
+    }
+}

--- a/src/test/java/doodoom/project/peermarket/security/SecurityTest.java
+++ b/src/test/java/doodoom/project/peermarket/security/SecurityTest.java
@@ -1,0 +1,113 @@
+package doodoom.project.peermarket.security;
+
+import doodoom.project.peermarket.configuration.SecurityConfig;
+import doodoom.project.peermarket.domain.Member;
+import doodoom.project.peermarket.service.member.MemberService;
+import doodoom.project.peermarket.type.MemberStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.logout;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Import(SecurityConfig.class)
+public class SecurityTest {
+
+    @MockBean
+    private MemberService memberService;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private MockMvc mockMvc;
+    private static final List<Member> members = new ArrayList<>();
+
+    @BeforeAll
+    public static void setUp() {
+        members.add(Member.builder()
+                .email("test@test.com")
+                .password("test123!")
+                .nickname("test")
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    @Test
+    public void loginSuccessTest() throws Exception {
+        //given
+        Member member = members.get(0);
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        given(memberService.loadUserByUsername(anyString()))
+                .willReturn(
+                        User.builder()
+                                .username(member.getEmail())
+                                .password(passwordEncoder.encode(member.getPassword()))
+                                .authorities(grantedAuthorities)
+                                .build());
+        //when
+        //then
+        mockMvc.perform(formLogin("/member/login")
+                        .user(member.getEmail())
+                        .password(member.getPassword()))
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(authenticated());
+    }
+
+    @Test
+    public void loginFailureTest() throws Exception {
+        //given
+        Member member = members.get(0);
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        given(memberService.loadUserByUsername(anyString()))
+                .willReturn(
+                        User.builder()
+                                .username(member.getEmail())
+                                .password(passwordEncoder.encode(member.getPassword()))
+                                .authorities(grantedAuthorities)
+                                .build());
+        //when
+        //then
+        mockMvc.perform(formLogin("/member/login")
+                        .user(anyString())
+                        .password(anyString()))
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/member/login?error=true"))
+                .andExpect(unauthenticated());
+    }
+
+    @Test
+    @WithMockUser(username = "test", roles = "USER")
+    public void logoutTest() throws Exception {
+        //then
+        mockMvc.perform(logout())
+                .andDo(print())
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrl("/"));
+    }
+}

--- a/src/test/java/doodoom/project/peermarket/service/member/MemberServiceTest.java
+++ b/src/test/java/doodoom/project/peermarket/service/member/MemberServiceTest.java
@@ -1,0 +1,90 @@
+package doodoom.project.peermarket.service.member;
+
+import doodoom.project.peermarket.domain.Member;
+import doodoom.project.peermarket.dto.MemberRegisterInput;
+import doodoom.project.peermarket.exception.MemberException;
+import doodoom.project.peermarket.repository.MemberRepository;
+import doodoom.project.peermarket.type.MemberStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static doodoom.project.peermarket.type.ErrorCode.EMAIL_ALREADY_EXIST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @InjectMocks
+    private MemberServiceImpl memberService;
+    private static final List<Member> members = new ArrayList<>();
+
+    @BeforeAll
+    public static void setUp() {
+        members.add(Member.builder()
+                .email("test@test.com")
+                .password("test123!")
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    @Test
+    public void registerSuccess() {
+        //given
+        Member member = members.get(0);
+        MemberRegisterInput input =
+                new MemberRegisterInput(member.getEmail(), member.getPassword(),
+                        member.getPassword(), member.getNickname());
+
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.empty());
+        given(passwordEncoder.encode(anyString()))
+                .willReturn(anyString());
+
+        ArgumentCaptor<Member> captor = ArgumentCaptor.forClass(Member.class);
+
+        //when
+        boolean b = memberService.register(input);
+
+        //then
+        assertThat(b).isTrue();
+        verify(memberRepository, times(1)).save(captor.capture());
+    }
+
+    @Test
+    public void registerFailure() {
+        //given
+        Member member = members.get(0);
+        MemberRegisterInput input =
+                new MemberRegisterInput(member.getEmail(), member.getPassword(),
+                        member.getPassword(), member.getNickname());
+
+        //when
+        given(memberRepository.findByEmail(anyString()))
+                .willReturn(Optional.of(member));
+
+        //then
+        MemberException exception = assertThrows(MemberException.class,
+                () -> memberService.register(input));
+        assertThat(exception.getErrorCode()).isEqualTo(EMAIL_ALREADY_EXIST);
+        assertThat(exception.getErrorMessage()).isEqualTo(EMAIL_ALREADY_EXIST.getDescription());
+    }
+}

--- a/src/test/java/doodoom/project/peermarket/validation/ValidationTest.java
+++ b/src/test/java/doodoom/project/peermarket/validation/ValidationTest.java
@@ -1,0 +1,77 @@
+package doodoom.project.peermarket.validation;
+
+import doodoom.project.peermarket.dto.MemberRegisterInput;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidationTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    public void emailValidation() throws Exception {
+        //given
+        MemberRegisterInput input = MemberRegisterInput.builder()
+                .email("test")
+                .password("test123!")
+                .passwordCheck("test123!")
+                .nickname("test")
+                .build();
+
+        //when
+        Set<ConstraintViolation<MemberRegisterInput>> validation =
+                validator.validate(input);
+
+        //then
+        assertThat(validation.size()).isEqualTo(1);
+        assertThat(validation.iterator().next().getMessage()).isEqualTo("올바른 " +
+                "형식의 이메일 주소여야 합니다.");
+    }
+
+    @Test
+    public void passwordValidation() throws Exception {
+        //given
+        MemberRegisterInput input = MemberRegisterInput.builder()
+                .email("test@test.com")
+                .password("testtest")
+                .passwordCheck("testtest")
+                .nickname("test")
+                .build();
+        //when
+        Set<ConstraintViolation<MemberRegisterInput>> validation =
+                validator.validate(input);
+
+        //then
+        assertThat(validation.size()).isEqualTo(1);
+        assertThat(validation.iterator().next().getMessage()).isEqualTo(
+                "비밀번호는 영어, 숫자를 포함해 8~20 글자이어야 합니다.");
+    }
+
+    @Test
+    public void passwordCheckValidation() throws Exception {
+        //given
+        MemberRegisterInput input = MemberRegisterInput.builder()
+                .email("test@test.com")
+                .password("test1234")
+                .passwordCheck("test12345")
+                .nickname("test")
+                .build();
+        //when
+        Set<ConstraintViolation<MemberRegisterInput>> validation =
+                validator.validate(input);
+
+        //then
+        assertThat(validation.size()).isEqualTo(1);
+        assertThat(validation.iterator().next().getMessage()).isEqualTo(
+                "비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/test/java/doodoom/project/peermarket/validation/ValidationTest.java
+++ b/src/test/java/doodoom/project/peermarket/validation/ValidationTest.java
@@ -1,9 +1,6 @@
 package doodoom.project.peermarket.validation;
 
 import doodoom.project.peermarket.dto.MemberRegisterInput;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
@@ -15,7 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ValidationTest {
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final Validator validator =
+            Validation.buildDefaultValidatorFactory().getValidator();
 
     @Test
     public void emailValidation() throws Exception {


### PR DESCRIPTION
### **변경 사항**

**AS-IS**

**TO-BE**
1. 회원 가입
    - 회원가입 페이지 접근
    - 이메일, 비밀번호, 비밀번호 확인, 닉네임 입력을 통한 회원가입
    - 입력 값 유효성 검사
        - 이메일 형식, 비밀번호 기준(영어, 숫자 무조건 포함한 8~20글자, 특수기호 포함 가능), 비밀번호 일치, 모든 값은 빈칸이면 안됨
        - 유효성 검증에 실패하면 에러페이지 반환(에러코드, 에러메시지 포함)
    - 이메일이 이미 있는 값이라면 에러페이지 반환(에러코드, 에러메시지 포함)
    - default status는 ACTIVE, default isAdmin은 false
    - 회원 생성일자와 수정일자 포함.
2. 로그인/ 로그아웃
    - session을 통한 로그인 전략 선택
    - 이메일, 비밀번호를 통한 로그인
    - 로그인 실패 시 로그인 페이지로 redirect
    - 해당 계정 정지 시 에러페이지 반환(에러코드, 에러미시지 포함)
 

### **테스트**

- [x]  테스트 코드
- [x]  API 테스트